### PR TITLE
fix wrong BOS response length in Linux, fix #45

### DIFF
--- a/components/USBIP/usb_handle.c
+++ b/components/USBIP/usb_handle.c
@@ -315,7 +315,9 @@ static void handleGetDescriptor(usbip_stage2_header *header)
 #if (USE_WINUSB == 1)
     case USB_DT_BOS:
         os_printf("* GET 0x0F BOS DESCRIPTOR\r\n");
-        send_stage2_submit_data(header, 0, bosDescriptor, sizeof(bosDescriptor));
+        uint32_t bos_len = header->u.cmd_submit.request.wLength.u8lo | ((uint32_t) header->u.cmd_submit.request.wLength.u8hi << 8);
+        bos_len = (sizeof(bosDescriptor) < bos_len) ? sizeof(bosDescriptor) : bos_len;
+        send_stage2_submit_data(header, 0, bosDescriptor, bos_len);
         break;
 #else
     case USB_DT_HID_REPORT:


### PR DESCRIPTION
Linux 在 USB 枚举中请求 BOS 时会先发一个 wLength 为 5 的 get descriptor request BOS 包，来获取 BOS 的前 5 字节中的长度信息，然后在下一个 request 中获取 BOS 全文。

若返回的数据长度比 wLength 大的话会导致 usbip 中的 `usbip_recv_xbuff` 出错，即日志中的
```
recv xbuf, 0
```