### PR TITLE
fix software reset by writing in SYSRESETQ register when a reset is requested

### DIFF
--- a/components/DAP/source/DAP.c
+++ b/components/DAP/source/DAP.c
@@ -273,6 +273,13 @@ static uint32_t DAP_Disconnect(uint8_t *response) {
 //   return:   number of bytes in response
 static uint32_t DAP_ResetTarget(uint8_t *response) {
 
+  /* Workaround for software reset when nRESET is not connected */
+  uint32_t AIRCR_REG_ADDR = 0xE000ED0C;
+  uint32_t AIRCR_RESET_VAL = (0x05FA << 16 | 1 << 2); /* Vector key | SYSRESETREQ bit */
+  SWD_Transfer(0x05,&AIRCR_REG_ADDR);
+  dap_os_delay(2);
+  SWD_Transfer(0x0d,&AIRCR_RESET_VAL);
+
   *(response+1) = RESET_TARGET();
   *(response+0) = DAP_OK;
   return (2U);


### PR DESCRIPTION
Hi, since software reset is never triggered, and hardware reset is triggered for both soft/hard.

I'm thinking why not add soft reset before hard reset for any reset request, that will make soft reset working when nRESET is not connected.

I added a write to `SYSRESETQ` register to trigger a software reset manually.

That cause software + hardware reset in anycase instead of hard reset only.

I have tested on esp32s3-WROOM-1-N16R8.

Can you test it on your side to confirm that is working ?